### PR TITLE
Fix saving/loading of gestures

### DIFF
--- a/Source/gestures/controllers/GestureController.hx
+++ b/Source/gestures/controllers/GestureController.hx
@@ -47,6 +47,8 @@ import sys.io.FileOutput;
         this.currentGesture = new Gesture();
         this.classifier = new Classifier();
 
+        loadGesturesFromFile();
+
         setupGesturesDirectory();
 
         sensorDataController.defaultFilteredSensorDatas[0].onUpdate.add(update);
@@ -157,24 +159,24 @@ import sys.io.FileOutput;
         }
     }
 
-    private function loadGesturesFromFile()
+    public function loadGesturesFromFile()
     {
         if(FileSystem.exists(FULL_FILENAME))
         {
-            var file:FileInput = File.read(FULL_FILENAME, false);
+            var file:FileInput = File.read(FULL_FILENAME, true);
             classifier = Classifier.fromFile(file);
             file.close();
         }
     }
 
-    private function writeGesturesToFile()
+    public function writeGesturesToFile()
     {
         if(FileSystem.exists(FULL_FILENAME))
         {
             FileSystem.deleteFile(FULL_FILENAME);
         }
 
-        var file:FileOutput = File.write(FULL_FILENAME, false);
+        var file:FileOutput = File.write(FULL_FILENAME, true);
         classifier.writeToFile(file);
         file.close();
     }

--- a/Source/gestures/models/GestureModel.hx
+++ b/Source/gestures/models/GestureModel.hx
@@ -130,7 +130,7 @@ class GestureModel {
         file.writeString(name);
         file.writeInt8(numStates);
         file.writeInt8(numObservations);
-        file.writeFloat(defaultProbability);
+        file.writeDouble(defaultProbability);
         markovModel.writeToFile(file);
         quantizer.writeToFile(file);
     }
@@ -150,7 +150,7 @@ class GestureModel {
         result.numObservations = file.readInt8();
         trace("GestureModel:fromFile numObservations " + result.numObservations);
 
-        result.defaultProbability = file.readFloat();
+        result.defaultProbability = file.readDouble();
         trace("GestureModel:fromFile defaultProbability " + result.defaultProbability);
 
         result.markovModel = HMM.fromFile(file);

--- a/Source/gestures/models/HMM.hx
+++ b/Source/gestures/models/HMM.hx
@@ -221,11 +221,11 @@ class HMM {
 
         for(i in 0...numStates)
         {
-            file.writeFloat(initialProbabilitiesForState[i]);
+            file.writeDouble(initialProbabilitiesForState[i]);
             for(j in 0...numStates)
             {
-                file.writeFloat(a[i][j]);
-                file.writeFloat(b[i][j]);
+                file.writeDouble(a[i][j]);
+                file.writeDouble(b[i][j]);
             }
         }
     }
@@ -242,14 +242,13 @@ class HMM {
 
         for(i in 0...numStates)
         {
-            result.initialProbabilitiesForState[i] = file.readFloat();
+            result.initialProbabilitiesForState[i] = file.readDouble();
             for(j in 0...numStates)
             {
-                result.a[i][j] = file.readFloat();
-                result.b[i][j] = file.readFloat();
+                result.a[i][j] = file.readDouble();
+                result.b[i][j] = file.readDouble();
             }
         }
-
         return result;
     }
 

--- a/Source/gestures/models/Quantizer.hx
+++ b/Source/gestures/models/Quantizer.hx
@@ -25,11 +25,8 @@ class Quantizer {
     public function new(numStates:Int)
     {
         this.numStates = numStates;
-        centeroids = [
-            new Array<Float>(),
-            new Array<Float>(),
-            new Array<Float>()
-        ];
+        centeroids = new Array<Array<Float>>();
+        ArrayUtils.init2DFloatArray(centeroids, 14);
         areCenteroidsTrained = false;
     }
 
@@ -213,13 +210,13 @@ class Quantizer {
     public function writeToFile(file:FileOutput)
     {
         file.writeInt8(numStates);
-        file.writeFloat(radius);
+        file.writeDouble(radius);
 
         for(i in 0...centeroids.length)
         {
             for(j in 0...centeroids[i].length)
             {
-                file.writeFloat(centeroids[i][j]);
+                file.writeDouble(centeroids[i][j]);
             }
         }
     }
@@ -230,17 +227,17 @@ class Quantizer {
         trace("Quantizer:fromFile numStates " + numStates);
 
         var result:Quantizer = new Quantizer(numStates);
-        result.radius = file.readFloat();
+        result.radius = file.readDouble();
         trace("Quantizer:fromFile radius " + result.radius);
 
-        var centeroidsLength:Int = 3;
-        var centeroidsInnerLength:Int = 14;
+        var centeroidsLength:Int = 14;
+        var centeroidsInnerLength:Int = 3;
 
         for(i in 0...centeroidsLength)
         {
             for(j in 0...centeroidsInnerLength)
             {
-                result.centeroids[i][j] = file.readFloat();
+                result.centeroids[i][j] = file.readDouble();
             }
         }
 

--- a/Source/views/GestureList.hx
+++ b/Source/views/GestureList.hx
@@ -20,6 +20,8 @@ class GestureList extends ScrollView {
     {
         super();
 
+        this._scrollSensitivity = 1;
+
         this.gestureController = gestureController;
 
         this.style.borderSize = 0;


### PR DESCRIPTION
The main issue was saving the Quantizer's centeroids incorrectly.
I'm also writing out doubles instead of floats, these showed better
accuracy than floats.
